### PR TITLE
chore(cicd): add pip cache to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.11
+        cache: "pip"
+        cache-dependency-path: pyproject.toml
 
     - name: Install dependencies
       run: |
@@ -61,6 +63,8 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         allow-prereleases: true
+        cache: "pip"
+        cache-dependency-path: pyproject.toml
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
- enable pip caching in the test workflow

## Rationale
Caching Python dependencies reduces CI duration and speeds contributor feedback.

## Details
- `actions/setup-python` now uses pip cache keyed off `pyproject.toml` for lint and test jobs